### PR TITLE
Allow newline at end of PRIVKEY_FILE

### DIFF
--- a/crypto.py
+++ b/crypto.py
@@ -9,6 +9,8 @@ from const import *
 if os.path.exists(PRIVKEY_FILE):
     with open(PRIVKEY_FILE, "r") as f:
         key = f.read()
+        if key[-1] == '\n':
+            key = key[:-1]
         if len(key) != 64:
             raise RuntimeError(
                 "Invalid key_x25519: expected 64 bytes, not {} bytes".format(len(key))


### PR DESCRIPTION
Without this fix it dies with an error about the file being 65 bytes when the hex string is newline-terminated.