### PR TITLE
Split push notifications across multiple oxenmq instances

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,18 @@
 
 cmake_minimum_required(VERSION 3.18)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  foreach(lang C CXX)
+    if(NOT DEFINED CMAKE_${lang}_COMPILER_LAUNCHER AND NOT CMAKE_${lang}_COMPILER MATCHES ".*/ccache")
+      message(STATUS "Enabling ccache for ${lang}")
+      set(CMAKE_${lang}_COMPILER_LAUNCHER ${CCACHE_PROGRAM} CACHE STRING "")
+    endif()
+  endforeach()
+endif()
+
 project(spns)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/spns.ini.example
+++ b/spns.ini.example
@@ -37,6 +37,15 @@ max_connects = 1000
 # often last somewhat longer than this, but this is the minimum).
 filter_lifetime = 300
 
+# How many separate oxenmq instances to start to talk to network service nodes.  Increasing this can
+# be helpful if a single oxenmq instance (typically the proxy thread) starts bottlenecking under
+# heavy load.  If this is set to 1 or greater then this many extra servers are started and each
+# connection to a remote service node is assigned in round-robin order across the instances, while
+# the main local oxenmq instance will be used only for non-push requests (subscriptions, timers,
+# communication with notifiers, local admin stats endpoints, etc.).  If unset or set to 0 then just
+# one oxenmq instance will be used for everything (both local and push traffic).
+#omq_push_instances = 4
+
 # How long the main hivemind process will wait at startup before establishing connections to
 # the network's service nodes.  This delay is designed to allow subordinate notification processes
 # to connect to the hivemind to ensure that notification services are ready after a restart before

--- a/spns/config.hpp
+++ b/spns/config.hpp
@@ -43,6 +43,12 @@ struct Config {
     // How often we recheck for re-subscriptions for push renewals, expiries, etc.
     std::chrono::seconds subs_interval = 30s;
 
+    // Number of extra oxenmq instances to start up for push notifications.  If 0 then no extra ones
+    // are started and just the main oxenmq instance is used for everything.  The extra instances
+    // are used exlusively for push notifications; each connection to a new SN is round-robin
+    // assigned across the instances.
+    int omq_push_instances = 0;
+
     // Maximum connections we will attempt to establish simultaneously (we can have more, we just
     // won't try to open more than this at once until some succeed or fail).  You can set this to 0
     // for a "dry run" mode where no connections at all will be made.

--- a/spns/config.py
+++ b/spns/config.py
@@ -102,6 +102,7 @@ def load_config():
             "subs_interval": ("subs_interval", None, int),
             "max_connects": ("max_pending_connects", None, int),
             "filter_lifetime": ("filter_lifetime", None, int),
+            "omq_push_instances": ("omq_push_instances", None, int),
             "startup_wait": ("notifier_wait", None, lambda x: round(1000 * float(x))),
             "notifiers_expected": (
                 "notifiers_expected",

--- a/spns/hivemind.cpp
+++ b/spns/hivemind.cpp
@@ -49,16 +49,44 @@ HiveMind::HiveMind(Config conf_in) :
 
     sd_notify(0, "STATUS=Initializing OxenMQ");
 
-    omq_.log_level(
-            oxenmq::LogLevel::debug);  // Get everything (except trace) and let our logger filter it
+    // Ignore debugging and below; get everything else and let our logger filter it
+    omq_.log_level(oxenmq::LogLevel::info);
 
-    omq_.MAX_SOCKETS = 50000;
-    omq_.MAX_MSG_SIZE = 10 * 1024 * 1024;
+    while (omq_push_.size() < config.omq_push_instances) {
+        auto& o = omq_push_.emplace_back(
+                std::string{config.pubkey.sv()},
+                std::string{config.privkey.sv()},
+                false,
+                nullptr,
+                omq_log);
+        o.MAX_SOCKETS = 50000;
+        o.MAX_MSG_SIZE = 10 * 1024 * 1024;
+        o.EPHEMERAL_ROUTING_ID = false;
+        o.log_level(oxenmq::LogLevel::info);
+        // Since we're splitting the load, we reduce number of workers per push server to
+        // ceil(instances/N) + 1 (the +1 because the load is probably not perfectly evenly
+        // distributed).
+        o.set_general_threads(
+                1 + (std::thread::hardware_concurrency() + config.omq_push_instances - 1) /
+                            config.omq_push_instances);
+    }
+    omq_push_next_ = omq_push_.begin();
 
-    // We always need to ensure we have some batch threads available because for swarm updates
-    // we keep a lock held during the batching and need to ensure that there will always be some
-    // workers available, even if a couple workers lock waiting on that lock.
-    omq_.set_batch_threads(std::max<int>(std::thread::hardware_concurrency(), 4));
+    if (omq_push_.empty()) {
+        // the main omq_ is dealing with push conns and notifications so increase limits
+        omq_.MAX_SOCKETS = 50000;
+        omq_.MAX_MSG_SIZE = 10 * 1024 * 1024;
+        omq_.EPHEMERAL_ROUTING_ID = false;
+
+        // We always need to ensure we have some batch threads available because for swarm updates
+        // we keep a lock held during the batching and need to ensure that there will always be some
+        // workers available, even if a couple workers lock waiting on that lock.
+        omq_.set_batch_threads(std::max<int>(4, std::thread::hardware_concurrency() / 2));
+    } else {
+        // When in multi-instance mode the main worker can get by with fewer threads
+        omq_.set_general_threads(std::max<int>(4, std::thread::hardware_concurrency() / 4));
+        omq_.set_batch_threads(std::max<int>(4, std::thread::hardware_concurrency() / 4));
+    }
 
     // We listen on a local socket for connections from other local services (web frontend,
     // notification services).
@@ -90,19 +118,24 @@ HiveMind::HiveMind(Config conf_in) :
         log::info(cat, "Listening for incoming connections on {}", log_addr);
     }
 
+    // Invoked by our oxend to notify of a new block:
     omq_.add_category("notify", oxenmq::AuthLevel::basic)
+            .add_command("block", ExcWrapper{*this, &HiveMind::on_new_block, "on_new_block"});
 
-            // Invoked by our oxend to notify of a new block:
-            .add_command("block", ExcWrapper{*this, &HiveMind::on_new_block, "on_new_block"})
-
-            // Invoke by a remote swarm to notify of a new message:
-            .add_command(
-                    "message",
-                    ExcWrapper{
-                            *this, &HiveMind::on_message_notification, "on_message_notification"})
-
-            // end of "notify." commands
-            ;
+    if (omq_push_.empty())
+        omq_.add_request_command(
+                "notify",
+                "message",
+                ExcWrapper{*this, &HiveMind::on_message_notification, "on_message_notification"});
+    else
+        for (auto& push : omq_push_)
+            push.add_category("notify", oxenmq::AuthLevel::basic)
+                    .add_command(
+                            "message",
+                            ExcWrapper{
+                                    *this,
+                                    &HiveMind::on_message_notification,
+                                    "on_message_notification"});
 
     omq_.add_category("push", oxenmq::AuthLevel::none)
 
@@ -221,6 +254,8 @@ HiveMind::HiveMind(Config conf_in) :
         sd_notify(0, "STATUS=Starting OxenMQ");
         log::info(cat, "Starting OxenMQ");
         omq_.start();
+        for (auto& o : omq_push_)
+            o.start();
 
         log::info(cat, "Started OxenMQ");
 
@@ -1183,8 +1218,15 @@ void HiveMind::on_sns_response(std::vector<std::string> data) {
                 // otherwise.
                 snode->connect(std::move(addr));
             } else {
+                // If we are using separate oxenmq instances for push handling then select the next
+                // one, round-robin style:
+                if (!omq_push_.empty() && omq_push_next_ == omq_push_.end())
+                    omq_push_next_ = omq_push_.begin();
+
+                auto& omq_instance = omq_push_.empty() ? omq_ : *omq_push_next_++;
                 // New snode
-                auto snode = std::make_shared<hive::SNode>(*this, omq_, std::move(addr), swarm);
+                auto snode =
+                        std::make_shared<hive::SNode>(*this, omq_instance, std::move(addr), swarm);
                 sns_.emplace(xpk, snode);
                 swarms_[swarm].insert(snode);
                 new_or_changed_sns.insert(snode);

--- a/spns/hivemind.cpp
+++ b/spns/hivemind.cpp
@@ -308,7 +308,7 @@ HiveMind::HiveMind(Config conf_in) :
         prom.get_future().get();
         log::info(cat, "Connected to oxend");
 
-        sd_notify(0, "STATUS=Waiting for notifiers");
+        sd_notify(0, "READY=1\nSTATUS=Waiting for notifiers");
 
         if (config.notifier_wait > 0s) {
             // Wait for notification servers that start up before or alongside us to connect:
@@ -384,7 +384,6 @@ void HiveMind::set_ready() {
         std::lock_guard lock{deferred_mutex_};
         ready = true;
     }
-    log_stats("READY=1");
 
     while (!deferred_.empty()) {
         std::move(deferred_.front())();

--- a/spns/hivemind.hpp
+++ b/spns/hivemind.hpp
@@ -116,7 +116,11 @@ class HiveMind {
 
   private:
     std::mutex mutex_;
+    // OxenMQ server for internal communications, proxied subscriptions, etc.
     oxenmq::OxenMQ omq_;
+    // OxenMQ *clients* that connect to service nodes, if the omq_push_instances setting is used.
+    std::list<oxenmq::OxenMQ> omq_push_;
+    decltype(omq_push_)::iterator omq_push_next_;
     PGConnPool pool_;
 
     // xpk -> SNode

--- a/spns/pybind.cpp
+++ b/spns/pybind.cpp
@@ -111,6 +111,13 @@ PYBIND11_MODULE(core, m) {
                     "how frequently, in seconds, between subscription rechecks (for push renewals, "
                     "expiries, etc.)")
             .def_readwrite(
+                    "omq_push_instances",
+                    &Config::omq_push_instances,
+                    "How many dedicated oxenmq instances to use for handle push notifications; if "
+                    "1 or greater then this many separate oxenmq instances will be started to deal "
+                    "with push requests; if 0 then the main oxenmq server will be used for "
+                    "everything.")
+            .def_readwrite(
                     "max_pending_connects",
                     &Config::max_pending_connects,
                     "maximum number of permitted simultaneous connection attempts.  (This is not "


### PR DESCRIPTION
The number of push notifications we are getting is sometimes hitting a limit on how many requests we can handle through the oxenmq proxy server at once.  This suggests oxenmq's proxy thread needs some attention for optimization, but this change in the meantime deals with it in hivemind by starting up OxenMQ instances for push notification handling to distribute the load.

This also reduces the number of threads when in such a mode for both the push and the main oxenmq instances as it makes no sense to use hardware_concurrency on *each* of multiple oxenmq servers, especially when running on a 24-thread server.