### PR TITLE
Disable including timestamp for Session Android

### DIFF
--- a/spns/notifiers/firebase.py
+++ b/spns/notifiers/firebase.py
@@ -69,7 +69,10 @@ def validate(msg: Message):
 def push_notification(msg: Message):
     data = oxenc.bt_deserialize(msg.data()[0])
 
-    enc_payload = encrypt_notify_payload(data, max_msg_size=MAX_MSG_SIZE)
+    # TODO: remote `include_ts=False` parameter here start including timestamps; current Android
+    # release breaks when receiving extra fields, so it is disabled for now until we have a release
+    # (and enough time for upgrades).
+    enc_payload = encrypt_notify_payload(data, max_msg_size=MAX_MSG_SIZE, include_ts=False)
 
     device_token = data[b"&"].decode()  # unique service id, as we returned from validate
 

--- a/spns/notifiers/huawei.py
+++ b/spns/notifiers/huawei.py
@@ -68,7 +68,10 @@ def validate(msg: Message):
 def push_notification(msg: Message):
     data = oxenc.bt_deserialize(msg.data()[0])
 
-    enc_payload = encrypt_notify_payload(data, max_msg_size=MAX_MSG_SIZE)
+    # TODO: remote `include_ts=False` parameter here start including timestamps; current Android
+    # release breaks when receiving extra fields, so it is disabled for now until we have a release
+    # (and enough time for upgrades).
+    enc_payload = encrypt_notify_payload(data, max_msg_size=MAX_MSG_SIZE, include_ts=False)
 
     device_token = data[b"&"].decode()  # unique service id, as we returned from validate
 

--- a/spns/notifiers/util.py
+++ b/spns/notifiers/util.py
@@ -36,10 +36,14 @@ def encrypt_payload(msg: bytes, enc_key: bytes):
     return nonce + ciphertext
 
 
-def encrypt_notify_payload(data: dict, max_msg_size: int = 2500):
+def encrypt_notify_payload(data: dict, max_msg_size: int = 2500, include_ts: bool = True):
     enc_key = data[b"^"]
 
     metadata = {"@": data[b"@"].hex(), "#": data[b"#"].decode(), "n": data[b"n"], "t": data[b"t"], "z": data[b"z"]}
+    if not include_ts:
+        for t in ("t", "z"):
+            del metadata[t]
+
     body = data.get(b"~")
 
     if body:


### PR DESCRIPTION
It breaks on the extra "t" and "z" fields; we will re-enable once supported and enough time has passed for users to upgrade to a new, supporting release.